### PR TITLE
Set SP-R as Marksman Rifle

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -426,7 +426,8 @@ export default new Vuex.Store({
             'MK2 Carbine': '50 Longshot Kills',
             'Kar98k': '50 Longshot Kills',
             'Crossbow': '50 Longshot Kills',
-            'SKS': '25 Double Kills'
+            'SKS': '25 Double Kills',
+            'SP-R 208': '50 Longshot Kills'
           },
           'Sniper Rifle': '50 Longshot Kills',
           'Melee': {
@@ -1384,6 +1385,21 @@ export default new Vuex.Store({
           }
         },
         {
+          category: 'Marksman Rifle',
+          alias: 'Foxtrot',
+          name: 'SP-R 208',
+          required: false,
+          progress: {
+            ...defaultProgress
+          },
+          mastery: {
+            ...defaultMastery
+          },
+          challenges: {
+            ...defaultChallenges('Marksman Rifle')
+          }
+        },
+        {
           category: 'Sniper Rifle',
           alias: 'Alpha',
           name: 'Dragunov',
@@ -1432,21 +1448,6 @@ export default new Vuex.Store({
           category: 'Sniper Rifle',
           alias: 'Delta',
           name: 'Rytek AMR',
-          required: false,
-          progress: {
-            ...defaultProgress
-          },
-          mastery: {
-            ...defaultMastery
-          },
-          challenges: {
-            ...defaultChallenges('Sniper Rifle')
-          }
-        },
-        {
-          category: 'Sniper Rifle',
-          alias: 'Echo',
-          name: 'SP-R 208',
           required: false,
           progress: {
             ...defaultProgress


### PR DESCRIPTION
Hey @carlssonemil 

Just a quick fix to move the SP-R 208 to the Marksman category. Changes look weird due to all the JSON blocks being a similar shape and git getting confused which lines changed! All I did was cut-paste the SP-R further up and change its category. Also set the Topo challenge description as all Marksmans have it unique.

Cheers!